### PR TITLE
There is no information about connection failure

### DIFF
--- a/lib/PoolConnectionManager.js
+++ b/lib/PoolConnectionManager.js
@@ -444,6 +444,9 @@ PoolConnectionManager.prototype._createNewIdleConnection = function (callback) {
   connection.connect(this._timeoutConfig, function onConnect(err) {
     if (pool._isClosed() || err) {
       if (callback) {
+        if (err){
+            pool.emit('error', err);
+        }
         callback(false);
       }
       return;


### PR DESCRIPTION
Hello, i've made a little improvement in your library for better handling connection errors.
When you set **invalid** or non-existing mysql **hostname** or the server doesn't respond, there is **no error** to catch. You have no idea what is happening then.

For example:
```js
const mysqlBoosted = MysqlPoolBooster(mysql);
const pool = mysqlBoosted.createPool(config);

pool.getConnection((err, conn) => {
	// err is never not-null
	return conn;
});
```
Do you have other ideas how to improve this to better error handling? Thank you for you work.